### PR TITLE
SLO logging params added

### DIFF
--- a/tools/python-contrailctl/schema/agent.json
+++ b/tools/python-contrailctl/schema/agent.json
@@ -148,6 +148,14 @@
         "backup_file_count": {
           "description": "Number of backup files",
           "type": "string"
+        },
+        "slo_destination_list": {
+          "description": "Destination to which slo session messages have to be sent: collector, file, syslog",
+          "type": "string"
+        },
+        "sample_destination_list": {
+          "description": "Destination to which sample session messages have to be sent: collector, file, syslog",
+          "type": "string"
         }
       }
     },


### PR DESCRIPTION
Destination for SLO and sampled sessions can be created
using slo_destination_list and sample_destination_list
with space separated values. The values can be one of
collector, syslog file or empty.

Change-Id: Ib68ab5e1674217fed7b706023625cd6f55933ccc
Partial-Bug: 1729812